### PR TITLE
Add Python SDK code samples

### DIFF
--- a/assets/rest/samples/python/AccountsAPI.getAccount.get.py
+++ b/assets/rest/samples/python/AccountsAPI.getAccount.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    acc = api.accounts.get_account('8093718274007724701R')
+    print('Balance: {} RISE'.format(acc.balance.to_unit()))
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/AccountsAPI.getDelegates.get.py
+++ b/assets/rest/samples/python/AccountsAPI.getDelegates.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    delegates = api.accounts.get_account_delegates('8093718274007724701R')
+    print(delegates[0].public_key.hex())
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/BlocksAPI.getBlock.get.py
+++ b/assets/rest/samples/python/BlocksAPI.getBlock.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    block = api.blocks.get_block('1359353064084280533')
+    print(block.height)
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/BlocksAPI.getBlocks.get.py
+++ b/assets/rest/samples/python/BlocksAPI.getBlocks.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    res = api.blocks.get_blocks(limit=3)
+    print(res.blocks[0].block_id) # 1894880255589205181
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/BlocksAPI.getFees.get.py
+++ b/assets/rest/samples/python/BlocksAPI.getFees.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    res = api.blocks.get_fees()
+    print(res.fees.send) # 10000000
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/BlocksAPI.getStatus.get.py
+++ b/assets/rest/samples/python/BlocksAPI.getStatus.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    status = api.blocks.get_status()
+    print(status.height) # 1356378
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.count.get.py
+++ b/assets/rest/samples/python/DelegatesAPI.count.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    count = api.delegates.get_delegate_count()
+    print(count) # 5278
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.forgingDisable.put.py
+++ b/assets/rest/samples/python/DelegatesAPI.forgingDisable.put.py
@@ -1,0 +1,7 @@
+from risesdk import APIError, Client
+
+api = Client('http://localhost:5566/api/')
+try:
+    api.delegates.disable_forging('your account secret')
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.forgingEnable.put.py
+++ b/assets/rest/samples/python/DelegatesAPI.forgingEnable.put.py
@@ -1,0 +1,7 @@
+from risesdk import APIError, Client
+
+api = Client('http://localhost:5566/api/')
+try:
+    api.delegates.enable_forging('your account secret')
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.getDelegate.get.py
+++ b/assets/rest/samples/python/DelegatesAPI.getDelegate.get.py
@@ -1,0 +1,9 @@
+from risesdk import PublicKey, APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+delegate_pk = PublicKey.fromhex('7067a911f3a4e13facbae9006b52a0c3ac9824bdd9f37168303152ae49dcb1c0')
+try:
+    delegate = api.delegates.get_delegate(delegate_pk)
+    print(delegate.username) # official_pool
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.getDelegates.get.py
+++ b/assets/rest/samples/python/DelegatesAPI.getDelegates.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    res = api.delegates.get_delegates(limit=3)
+    print(res.delegates[0].username) # official_pool
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.getForgedByAccount.get.py
+++ b/assets/rest/samples/python/DelegatesAPI.getForgedByAccount.get.py
@@ -1,0 +1,9 @@
+from risesdk import PublicKey, APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+delegate_pk = PublicKey.fromhex('7067a911f3a4e13facbae9006b52a0c3ac9824bdd9f37168303152ae49dcb1c0')
+try:
+    res = api.delegates.get_forged_by_account(delegate_pk)
+    print(res.forged) # 19066025346961
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.getForgingStatus.get.py
+++ b/assets/rest/samples/python/DelegatesAPI.getForgingStatus.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('http://localhost:5566/api/')
+try:
+    res = api.delegates.get_forging_status()
+    print(res.enabled) # true
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.getNextForgers.get.py
+++ b/assets/rest/samples/python/DelegatesAPI.getNextForgers.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    res = api.delegates.get_next_forgers()
+    print(res.delegates[0].hex()) # a65a8160b1e07...
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.getVoters.get.py
+++ b/assets/rest/samples/python/DelegatesAPI.getVoters.get.py
@@ -1,0 +1,9 @@
+from risesdk import PublicKey, APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+delegate_pk = PublicKey.fromhex('a65a8160b1e0733f66d1f1a8f322c9af29b26d5e491a84d6e3ae0ec43e000446')
+try:
+    voters = api.delegates.get_voters(delegate_pk)
+    print(len(voters)) # 5
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/DelegatesAPI.search.get.py
+++ b/assets/rest/samples/python/DelegatesAPI.search.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    delegates = api.delegates.search_delegates('pool')
+    print(delegates[0].username) # official_pool
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/TransactionsAPI.getCount.get.py
+++ b/assets/rest/samples/python/TransactionsAPI.getCount.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    counts = api.transactions.get_transaction_count()
+    print(counts.confirmed) # 563381
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/TransactionsAPI.getTX.get.py
+++ b/assets/rest/samples/python/TransactionsAPI.getTX.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    tx = api.transactions.get_transaction('6920969059388666996')
+    print(tx.confirmations) # 838512
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/TransactionsAPI.getTransactions.get.py
+++ b/assets/rest/samples/python/TransactionsAPI.getTransactions.get.py
@@ -1,0 +1,12 @@
+from risesdk import APIError, Client, RegisterDelegateTx
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    res = api.transactions.get_transactions(
+        and__type_cls=RegisterDelegateTx,
+        limit=1,
+        order_by='height:desc',
+    )
+    print('Newest delegate:', res.transactions[0].tx.username)
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/TransactionsAPI.getUnconfirmedTx.get.py
+++ b/assets/rest/samples/python/TransactionsAPI.getUnconfirmedTx.get.py
@@ -1,0 +1,9 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    utx = api.transactions.get_unconfirmed_transaction('6920969059388666996')
+    if utx is not None:
+        print(utx.tx.fee) # 10000000
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/TransactionsAPI.getUnconfirmedTxs.get.py
+++ b/assets/rest/samples/python/TransactionsAPI.getUnconfirmedTxs.get.py
@@ -1,0 +1,8 @@
+from risesdk import APIError, Client
+
+api = Client('https://wallet.rise.vision/api/')
+try:
+    res = api.transactions.get_unconfirmed_transactions()
+    print(res.count) # 3
+except APIError as err:
+    print('API error:', err)

--- a/assets/rest/samples/python/TransactionsAPI.put.put.py
+++ b/assets/rest/samples/python/TransactionsAPI.put.put.py
@@ -1,0 +1,17 @@
+from risesdk import APIError, Client, PublicKey, Address, Amount, SendTx
+
+api = Client('https://wallet.rise.vision/api/')
+
+tx = SendTx(
+    sender_public_key=PublicKey.fromhex('bf4809a1a08c9dffbba741f0c7b9f49145602341d5fa306fb3cd592d3e1058b3'),
+    recipient=Address('3303015780877366956R'),
+    amount=Amount.from_unit('1995.33766861'),
+    fee=Amount.from_unit('0.1'),
+)
+# tx.signature = sk.sign(tx.to_bytes())
+
+try:
+    res = api.transactions.add_transactions(tx)
+    print(len(res.accepted)) # 1
+except APIError as err:
+    print('API error:', err)

--- a/rc-openapi-gen.conf.js
+++ b/rc-openapi-gen.conf.js
@@ -37,6 +37,9 @@ module.exports = {
     languages: {
       javascript: {
         extension: 'js'
+      },
+      python: {
+        extension: 'py'
       }
     }
   }


### PR DESCRIPTION
Add new Python SDK code samples to the API reference.

I couldn't really see if they worked because neither `npm run build:dev` nor `npm run build` produced something that worked (got some typescript definition errors for the build:dev and missing './md' module error for build). So I'm going out on a limb and hoping that everything is in order 👼 